### PR TITLE
Split PSTATE

### DIFF
--- a/instrs-sys.sail
+++ b/instrs-sys.sail
@@ -79,25 +79,20 @@ function clause decode (0b11010110100111110000001111100000) = {
 }
 
 function clause execute ExceptionReturn() = {
+  assert (CurrentEL != 0b00, "Trying to ERET from EL0, fault not implemented");
   /* Set PC to the exception link register (no +4 increment) */
   _PC = ELR_EL1;
 
   /* Read saved program status register */
   let spsr = SPSR_EL1;
+  assert (spsr[4..4] == 0b0, "AArch32 not supported");
+  assert (spsr[3..2] == 0b00 | spsr[3..2] == 0b01,
+          "EL2 and EL3 not supported");
+  assert (spsr[3..0] != 0b0001, "Can't have SPSel set to 1 in EL0");
 
-  /* Restore PSTATE fields from SPSR */
-  let new_pstate = {PSTATE with
-    N = spsr[31..31],
-    Z = spsr[30..30],
-    C = spsr[29..29],
-    V = spsr[28..28],
-    D = spsr[9..9],
-    A = spsr[8..8],
-    I = spsr[7..7],
-    F = spsr[6..6],
-    EL = spsr[3..2],
-    SP = spsr[0..0]
-  };
-  PSTATE = new_pstate;
+  NZCV = spsr[31..28];
+  DAIF = spsr[9..6];
+  CurrentEL = spsr[3..2];
+  SPSel = spsr[0..0];
 }
 $endif

--- a/interface.sail
+++ b/interface.sail
@@ -92,12 +92,11 @@ function base_AccessDescriptor (acctype : AccessType) -> AccessDescriptor = stru
   }
 }
 
-$ifdef SYSTEM_TINY_ARM
 function create_writeAccessDescriptor() -> AccessDescriptor = {
   var accdesc = base_AccessDescriptor(AccessType_GPR);
   accdesc.write = true;
   accdesc.read = false;
-  accdesc.el = PSTATE.EL;
+  accdesc.el = CurrentEL;
   accdesc
 }
 
@@ -105,7 +104,7 @@ function create_readAccessDescriptor() -> AccessDescriptor = {
   var accdesc = base_AccessDescriptor(AccessType_GPR);
   accdesc.read = true;
   accdesc.write = false;
-  accdesc.el = PSTATE.EL;
+  accdesc.el = CurrentEL;
   accdesc
 }
 
@@ -113,34 +112,9 @@ function create_iFetchAccessDescriptor() -> AccessDescriptor = {
   var accdesc = base_AccessDescriptor(AccessType_IFETCH);
   accdesc.read = true;
   accdesc.write = false;
-  accdesc.el = PSTATE.EL;
+  accdesc.el = CurrentEL;
   accdesc
 }
-$else
-function create_writeAccessDescriptor() -> AccessDescriptor = {
-  var accdesc = base_AccessDescriptor(AccessType_GPR);
-  accdesc.write = true;
-  accdesc.read = false;
-  accdesc.el = 0b00;
-  accdesc
-}
-
-function create_readAccessDescriptor() -> AccessDescriptor = {
-  var accdesc = base_AccessDescriptor(AccessType_GPR);
-  accdesc.read = true;
-  accdesc.write = false;
-  accdesc.el = 0b00;
-  accdesc
-}
-
-function create_iFetchAccessDescriptor() -> AccessDescriptor = {
-  var accdesc = base_AccessDescriptor(AccessType_IFETCH);
-  accdesc.read = true;
-  accdesc.write = false;
-  accdesc.el = 0b00;
-  accdesc
-}
-$endif
 
 $ifdef SYSTEM_TINY_ARM
 enum DescriptorType = {

--- a/registers.sail
+++ b/registers.sail
@@ -146,41 +146,17 @@ function wPC(pc : bits(64)) -> unit = _PC = pc
 overload PC = {rPC, wPC}
 
 $ifdef SYSTEM_TINY_ARM
+register CurrentEL : bits(2)
+$else
+let CurrentEL : bits(2) = 0b00
+$endif
 
-struct ProcState = {
-  N : bits(1),
-  Z : bits(1),
-  C : bits(1),
-  V : bits(1),
-  D : bits(1),
-  A : bits(1),
-  I : bits(1),
-  F : bits(1),
-  EXLOCK : bits(1),
-  PAN : bits(1),
-  UAO : bits(1),
-  DIT : bits(1),
-  TCO : bits(1),
-  PM : bits(1),
-  PPEND : bits(1),
-  BTYPE : bits(2),
-  ZA : bits(1),
-  SM : bits(1),
-  ALLINT : bits(1),
-  SS : bits(1),
-  IL : bits(1),
-  EL : bits(2),
-  nRW : bits(1),
-  SP : bits(1),
-  Q : bits(1),
-  GE : bits(4),
-  SSBS : bits(1),
-  IT : bits(8),
-  J : bits(1),
-  T : bits(1),
-  E : bits(1),
-  M : bits(5)
-}
+register NZCV : bits(4)
+
+$ifdef SYSTEM_TINY_ARM
+
+register SPSel : bits(1)
+register DAIF : bits(4)
 
 // We fix the size to 64 and happyly ignore 128 bits register extension for VMSA128
 
@@ -192,12 +168,6 @@ register SP_EL3 : bits(64)
 register ELR_EL1 : bits(64)
 register ELR_EL2 : bits(64)
 register ELR_EL3 : bits(64)
-
-$ifdef SYSTEM_TINY_ARM
-register PSTATE : ProcState
-$else
-register PSTATE : bits(64)
-$endif
 
 register ESR_EL1 : bits(64)
 register ESR_EL2 : bits(64)

--- a/translation.sail
+++ b/translation.sail
@@ -30,7 +30,7 @@ function extract_perms_leaf(descriptor : bits(64)) -> Permissions = {
 
 function create_AccessDescriptorTTW (toplevel : bool, varange : VARange) -> AccessDescriptor = {
   var accdesc : AccessDescriptor = base_AccessDescriptor(AccessType_TTW);
-  accdesc.el = PSTATE.EL;
+  accdesc.el = CurrentEL;
   accdesc.read = true;
   accdesc.toplevel = toplevel;
   accdesc.varange = varange;
@@ -188,12 +188,12 @@ function take_exception(target_el : bits(2), fault : option(FaultRecord)) -> uni
   /* Declare the exception to the concurrent model (no-op otherwise) */
   sail_take_exception(fault);
 
-  let source_el = PSTATE.EL;
+  let source_el = CurrentEL;
 
   /* Determine vector offset based on source EL */
   let vect_offset : bits(12) =
     if source_el == target_el then {
-      if PSTATE.SP == 0b0 then 0x000 else 0x200
+      if SPSel == 0b0 then 0x000 else 0x200
     } else {
       0x400
     };
@@ -202,29 +202,12 @@ function take_exception(target_el : bits(2), fault : option(FaultRecord)) -> uni
   _PC = VBAR_EL1[63..12] @ vect_offset;
  
   /* Save PSTATE to SPSR_EL1 */
-  SPSR_EL1 = sail_zero_extend(
-    PSTATE.N @ PSTATE.Z @ PSTATE.C @ PSTATE.V @
-    0b0000000000000000000 @
-    PSTATE.D @
-    PSTATE.A @
-    PSTATE.I @
-    PSTATE.F @
-    0b00 @
-    PSTATE.EL @
-    0b0 @
-    PSTATE.SP,
-    64
-  );
+  SPSR_EL1 = sail_zeros(32)@NZCV@sail_zeros(18)@DAIF@0b00@CurrentEL@0b0@SPSel;
 
   /* Transition to EL1 and use SP_EL1 and mask interrupts*/
-  PSTATE = {PSTATE with
-    EL = 0b01,
-    SP = 0b1,
-    D = 0b1,
-    A = 0b1,
-    I = 0b1,
-    F = 0b1
-  };
+  CurrentEL = 0b01;
+  SPSel = 0b1;
+  DAIF = 0b1111;
 }
 
 function handle_fault (addrdesc : AddressDescriptor) -> unit = {


### PR DESCRIPTION
Currenlty we only need CurrentEL, SPSel, NZCV and DAIF (although we don't really use the last one)

Only NZCV is active in usermode (where CurrentEL is hard-wired to EL0)