### PR TITLE
Make system register IDs optional

### DIFF
--- a/instrs-sys.sail
+++ b/instrs-sys.sail
@@ -160,7 +160,7 @@ function clause execute SystemRegisterMove(is_read, sys_reg_id, t) = {
 
   _PC = _PC + 4;
 
-  if is_read then X(t) = sail_sys_reg_read(sys_reg_id, reg_ref)
-  else sail_sys_reg_write(sys_reg_id, reg_ref, X(t))
+  if is_read then X(t) = sail_sys_reg_read(Some(sys_reg_id), reg_ref)
+  else sail_sys_reg_write(Some(sys_reg_id), reg_ref, X(t))
 }
 $endif

--- a/interface.sail
+++ b/interface.sail
@@ -37,10 +37,10 @@ instantiation sail_translation_end with
   'trans_end = AddressDescriptor
 
 instantiation sail_sys_reg_read with
-  'sys_reg_id = SysRegID
+  'sys_reg_id = option(SysRegID)
 
 instantiation sail_sys_reg_write with
-  'sys_reg_id = SysRegID
+  'sys_reg_id = option(SysRegID)
 $endif
 
 function mem_acc_is_explicit     (acc : AccessDescriptor) -> bool = acc.acctype == AccessType_GPR


### PR DESCRIPTION
## Summary

Make system-register IDs optional, using `Some(id)` for ordinary system registers and reserving `None()` for PSTATE-backed special state.
